### PR TITLE
Update RTStruct conversion

### DIFF
--- a/bin/gt_dicom_rt_struct_to_image
+++ b/bin/gt_dicom_rt_struct_to_image
@@ -37,7 +37,7 @@ def gt_dicom_rt_struct_to_image(list_roi, filename_struct, filename_img, roi, cr
     gt.logging_conf(verbose=(verbose or list_roi),logfile=logfile)
 
     # read dicom struct
-    structset = pydicom.read_file(filename_struct)
+    structset = pydicom.read_file(filename_struct, force=True)
 
     # print roi names
     roi_names = gt.list_roinames(structset)
@@ -78,7 +78,7 @@ def gt_dicom_rt_struct_to_image(list_roi, filename_struct, filename_img, roi, cr
             mask = aroi.get_mask(img, corrected=False,pbar=pbar)
             if crop:
                 mask = gt.image_auto_crop(mask, bg=0)
-            output_filename = base_filename+'_'+roiname+'.mhd';
+            output_filename = base_filename + '_' + ''.join(e for e in roiname if e.isalnum()) +'.mhd';
             itk.imwrite(mask, output_filename)
         except Exception as e:
             tqdm.write(str(e))

--- a/gatetools/roi_utils.py
+++ b/gatetools/roi_utils.py
@@ -199,7 +199,8 @@ class contour_layer(object):
     def __repr__(self):
         return "contour layer {} with {} inclusion(s) and {} exclusion(s) at z = {}".format(self.name, len(self.inclusion), len(self.exclusion), self.z)
     def add_contour(self,points,ref=None):
-        assert(len(points)>2)
+        if len(points)<=2:
+            return
         assert(self.z == points[0,2])
         if self.ref is None:
             self.ref = ref


### PR DESCRIPTION
Be able to read dicom whithout header (with pydicom force to True)
Save the mhd ROI mask without special characther in the name (specially % and space that lead to failure during opening with ITK)
We have an example with a 2 points RTStruct, so I chose to return instead of an assert to avoid a total failure in the code