### PR TITLE
Patientorientation

### DIFF
--- a/gatetools/roi_utils.py
+++ b/gatetools/roi_utils.py
@@ -13,7 +13,7 @@ other clinics as well).
 Authors: David Boersma and Pierre Granger
 """
 
-from bounding_box import *
+from .bounding_box import *
 #from bounding_import bounding_box
 import logging
 logger = logging.getLogger()
@@ -821,7 +821,7 @@ import wget
 import tempfile
 import shutil
 
-from logging_conf import LoggedTestCase
+from .logging_conf import LoggedTestCase
 
 class Test_ROI(LoggedTestCase):
     def test_roi(self):


### PR DESCRIPTION
Some of the features in roi_utils.py were not working for patients in non-HFS (head first suppine) positions. 

I have updated get_ncorners() and get_mask() methods in the region_of_interest class to account for patient orientation. Have so far tested on two HFP, one FFS, and FFP patient.

I do not understand the "corrected=True/False" flag in the get_mask() method. Use of True is non-functional, due to line 633 trying to treat roimask as something other than an ITK image object. I have not corrected this - it may require further modifications to the correct_mask() method in the contour_layer class. For now, I have just changed the default value to corrected=False to help avoid this issue.

 