### PR TITLE
BUG: Volume of ROI incorrect.

### DIFF
--- a/gatetools/roi_utils.py
+++ b/gatetools/roi_utils.py
@@ -156,7 +156,7 @@ def enclosed_area(vs):
     a = 0
     x0,y0 = vs[0]
     logger.debug("x0={} y0={}".format(x0,y0))
-    for [x1,y1] in vs[1:]:
+    for [x1,y1] in np.vstack((vs, vs[0]))[1:]: # NK: calculate also segment from last to first vertex. If not, area is underestimated.
         dx = x1-x0
         dy = y1-y0
         a += 0.5*(y0*dx - x0*dy)


### PR DESCRIPTION
The volume of a ROI was underestimated. 
The loop in the function enclosed_area in roi_utils did not consider the 
area segment spanned by the last to the first vertex of the ROI contour 
layer. 
In general, this underestimates the area (and the volume) of the ROI. 
For small ROI layers, this even leads to negative area values. 

Example: 2x2 area should give 4, but previously gave 3 because one quarter of the square was ignored. 

```
vs = np.array([[-1,-1], [1, -1], [1, 1], [-1, 1]])
a = 0
x0,y0 = vs[0]
for [x1,y1] in np.vstack((vs, vs[0]))[1:]:
    dx = x1-x0
    dy = y1-y0
    a += 0.5*(y0*dx - x0*dy)
    x0 = x1
    y0 = y1
print(-a)
```